### PR TITLE
chore(rust,docker): update debian image and add g++ for cc-rs

### DIFF
--- a/rust/docker/debian/Dockerfile
+++ b/rust/docker/debian/Dockerfile
@@ -3,7 +3,7 @@
 # jomiel-client-demos
 #
 # Copyright
-#  2019-2022 Toni Gündoğdu
+#  2019-2022,2025 Toni Gündoğdu
 #
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -11,16 +11,14 @@
 
 # stage: bootstrap-image
 #
-FROM rust:1-slim-bullseye AS bootstrap-image
+FROM rust:1-slim-bookworm AS bootstrap-image
 
 WORKDIR /app
 
 COPY rust/Cargo.toml .
 COPY rust/Cargo.lock .
-
 COPY rust/src/ ./src/
 COPY rust/build.rs .
-
 COPY proto/ ./proto/
 
 RUN set -eux \
@@ -29,29 +27,21 @@ RUN set -eux \
         protobuf-compiler \
         libzmq3-dev \
         pkgconf \
+        g++ \
     && sed -i 's/\.\.\/proto/\.\/proto/' build.rs
 
-# stage: compile-image
-#
 FROM bootstrap-image AS compile-image
-
 RUN set -eux \
     ; cargo build --release
 
-# stage: runtime-image
-#
-FROM debian:bullseye-slim as runtime-image
-
+FROM debian:bookworm-slim AS runtime-image
 RUN set -eux \
     ; apt-get -qq update \
     && apt-get -qq --no-install-recommends install \
-        libprotobuf-lite23 \
-        libprotobuf23 \
         libzmq5 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=compile-image /app/target/release/demo /app/demo
 
 ENTRYPOINT ["/app/demo"]
-
 CMD ["-h"]


### PR DESCRIPTION
- bump base image to rust:1-slim-bookworm
- add g++ to build stage so cc-rs can find C++ compiler
- drop unused protobuf runtime libs (prost generates code at build time)
- keep only libzmq5 in runtime stage